### PR TITLE
💡 Fix the annoying 'Actual week' label

### DIFF
--- a/total-hours-worked.primaerp.user.js
+++ b/total-hours-worked.primaerp.user.js
@@ -54,10 +54,23 @@
         updateMonthTimes();
     }
 
+    function fixAnnoyingTranslations() {
+        console.log('Now fixing annoying translations...');
+        var annoyingTag = [...document.querySelectorAll('#week_time_chart svg g text')]
+            .filter(t => t.innerHTML == 'Actual week')[0];
+
+        if(annoyingTag) {
+            annoyingTag.innerHTML = 'Current week'
+        }
+    }
+
     function createWeekTimeChartObserver() {
         const weekTimeChart = document.getElementById(WEEK_TIME_CHART_ID);
         const options = { childList: true };
-        const observer = new MutationObserver(() => updateTimes());
+        const observer = new MutationObserver(() => {
+            fixAnnoyingTranslations();
+            updateTimes();
+        });
 
         observer.observe(weekTimeChart, options);
 

--- a/total-hours-worked.primaerp.user.js
+++ b/total-hours-worked.primaerp.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        primaERP - Total Hours Worked
-// @description Displays the total time worked in any week. Also offers a slim monthly report directly in the dashboard.
+// @description Displays the total time worked in any week. Also fixes some bad translations.
 // @author      Henrik Ilgen, https://github.com/henkoglobin; Johannes Feige,https://github.com/johannesfeige
 // @version     0.0.4
 // @grant       none

--- a/total-hours-worked.primaerp.user.js
+++ b/total-hours-worked.primaerp.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name        primaERP - Total Hours Worked
-// @description Displays the total time worked in any week.
+// @description Displays the total time worked in any week. Also offers a slim monthly report directly in the dashboard.
 // @author      Henrik Ilgen, https://github.com/henkoglobin; Johannes Feige,https://github.com/johannesfeige
-// @version     0.0.3
+// @version     0.0.4
 // @grant       none
 // @match       https://*.primaerp.com/
 // ==/UserScript==

--- a/total-hours-worked.primaerp.user.js
+++ b/total-hours-worked.primaerp.user.js
@@ -54,16 +54,6 @@
         updateMonthTimes();
     }
 
-    function fixAnnoyingTranslations() {
-        console.log('Now fixing annoying translations...');
-        var annoyingTag = [...document.querySelectorAll('#week_time_chart svg g text')]
-            .filter(t => t.innerHTML == 'Actual week')[0];
-
-        if(annoyingTag) {
-            annoyingTag.innerHTML = 'Current week'
-        }
-    }
-
     function createWeekTimeChartObserver() {
         const weekTimeChart = document.getElementById(WEEK_TIME_CHART_ID);
         const options = { childList: true };
@@ -88,6 +78,13 @@
                 .appendTo($heading);
             $('<div>', { class: 'desktop-panel-body', id: helper.getMonthDivComparisonId(month) }).appendTo($monthDiv);
         });
+    }
+    
+    function fixCurrentWeekTranslation() {
+        const weektime = window.messages.content.dashboard.panels.weektime;
+        if(weektime.actual() == "Actual week") {
+            weektime.actual = function() { return "Current week"; };
+        }   
     }
 
     /**
@@ -190,6 +187,7 @@
 
     createWeekTimeChartObserver();
     initMonths();
+    fixCurrentWeekTranslation();
 
     function getHelper() {
         const getMonthDivId = (month) => `${MONTH_DEV_PREFIX}${month.year()}-${month.month()}`;

--- a/total-hours-worked.primaerp.user.js
+++ b/total-hours-worked.primaerp.user.js
@@ -57,10 +57,7 @@
     function createWeekTimeChartObserver() {
         const weekTimeChart = document.getElementById(WEEK_TIME_CHART_ID);
         const options = { childList: true };
-        const observer = new MutationObserver(() => {
-            fixAnnoyingTranslations();
-            updateTimes();
-        });
+        const observer = new MutationObserver(() => updateTimes());
 
         observer.observe(weekTimeChart, options);
 


### PR DESCRIPTION
Currently, primaERP uses 'Actual week' when actually (no pun intended) it should be 'Current week'.
This PR fixes this annoying detail.